### PR TITLE
Add '.' in front of local module import names to fix the setup build for Python 3.10+

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Therefore, the `dict` built-in Python object is used to represent each block.
 
 ### Functions
 
-#### `load(f_obj, limit=-1, blocknames=set())`:
+#### `load(f_obj, blocknames=set())`:
 Returns a iterator/generator of SBF blocks.  
 `f_obj` should be a file object.  
 
@@ -49,7 +49,7 @@ Print the block name for the first 100 blocks:
 import pysbf
     
 with open('./dummy.sbf') as sbf_fobj:
- for blockName, block in pysbf.load(sbf_fobj, limit=100):
+ for blockName, block in pysbf.load(sbf_fobj):
   print blockName
 ```
       
@@ -59,7 +59,7 @@ Print the azimuth & elevation for each visible satellite using the first 100 *Sa
 import pysbf
     
 with open('./dummy.sbf') as sbf_fobj:
- for blockName, block in pysbf.load(sbf_fobj, limit=100, blocknames={'SatVisibility'}):
+ for blockName, block in pysbf.load(sbf_fobj, blocknames={'SatVisibility'}):
   for satInfo in block['SatInfo']:
    print satInfo['SVID'], satInfo['Azimuth'], satInfo['Elevation']
 ```
@@ -72,7 +72,7 @@ import numpy as np
 import pysbf as sbf
     
 with open('./dummy.sbf') as sbf_fobj:
- cpuload = ( '{} {}\n'.format(b['TOW'], b['CPULoad']) for bn, b in sbf.load(sbf_fobj, 100, {'ReceiverStatus_v2'}) )
+ cpuload = ( '{} {}\n'.format(b['TOW'], b['CPULoad']) for bn, b in sbf.load(sbf_fobj, {'ReceiverStatus_v2'}) )
  data = np.loadtxt(cpuload)
  plt.xlabel('Time (ms)')
  plt.ylabel('CPU Load (%)')

--- a/pysbf/sbf.pyx
+++ b/pysbf/sbf.pyx
@@ -1,9 +1,9 @@
 # Initial code by Jashandeep Sohi (2013, jashandeep.s.sohi@gmail.com)
 # adapted by Marco Job (2019, marco.job@bluewin.ch)
 
-from blocks import BLOCKNAMES, BLOCKNUMBERS
+from .blocks import BLOCKNAMES, BLOCKNUMBERS
 
-from parsers cimport BLOCKPARSERS
+from .parsers cimport BLOCKPARSERS
 
 from libc.stdint cimport uint16_t, uint8_t
 from libc.stdio cimport fread, fdopen, FILE, fseek, SEEK_CUR


### PR DESCRIPTION
- Add '.' in front of local module import names to fix the setup build for Python 3.10+. This resolves errors about missing modules seen if trying to build the pysbf module for latest python verstions
- Also edit README.md by removing `limit` argument from examples as such argument does not seem to be there  (any more?)

Tested that with these changes I can use the pysbf module to load sbf files in Python 3.10.10.